### PR TITLE
開発環境をDockerで立ち上げられるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.6.1
+
+RUN apt-get update -qq && \
+    apt-get install -qq --no-install-recommends build-essential libpq-dev mysql-client nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /app
+WORKDIR /app
+ADD Gemfile /app/Gemfile
+ADD Gemfile.lock /app/Gemfile.lock
+RUN bundle install
+ADD . /app

--- a/README.md
+++ b/README.md
@@ -13,3 +13,31 @@
 `「食べログ」`とは違って、
 
 `「鹿児島オフィスチームのおすすめするお店だけが載っていて、実際にそのお店に行ったペパボのパートナーのリアルな感想を見ることができる。」`のが特徴です。
+
+
+## 開発
+Dockerを使用して開発環境を立ち上げます。
+
+### 初回起動時
+
+```bash
+$ docker-compose build
+$ docker-compose run web bundle exec rake db:migrate
+
+# 初期データが必要な場合のみ
+$ docker-compose run web bundle exec rake db:seed
+
+$ docker-compose up -d
+```
+
+### 2回目以降の起動
+
+```
+$ docker-compose up -d
+```
+
+### 終了時
+
+```bash
+$ docker-compose stop
+```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ $ docker-compose run web bundle exec rake db:seed
 $ docker-compose up -d
 ```
 
+`localhost:3000`で立ち上がります。
+
 ### 2回目以降の起動
 
 ```

--- a/config/initializers/utf8mb4.rb
+++ b/config/initializers/utf8mb4.rb
@@ -1,0 +1,16 @@
+module Utf8mb4
+    def create_table(table_name, options = {})
+        table_options = options.merge(options: 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC')
+        super(table_name, table_options) do |td|
+            yield td if block_given?
+        end
+    end
+end
+
+ActiveSupport.on_load :active_record do
+    module ActiveRecord::ConnectionAdapters
+        class AbstractMysqlAdapter
+            prepend Utf8mb4
+        end
+    end
+end

--- a/database.yml
+++ b/database.yml
@@ -1,5 +1,4 @@
 default: &default
-  adapter: mysql2
   charset: utf8mb4
   encoding: utf8mb4
   collation: utf8mb4_general_ci
@@ -15,7 +14,8 @@ production:
   host:     <%= ENV["MC_DB_HOSTNAME"] %>
 
 development:
-  <<: *default
+  adapter: mysql2
+  encoding: utf8
   reconnect: false
   database: kagomeshi_development
   pool: 5
@@ -30,5 +30,5 @@ test:
   database: kagomeshi_test
   pool: 5
   username: root
-  password: password
-  host: db
+  password:
+  host: localhost

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,17 +12,17 @@
 
 ActiveRecord::Schema.define(version: 2019_04_25_073900) do
 
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,17 +33,17 @@ ActiveRecord::Schema.define(version: 2019_04_25_073900) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "comments", force: :cascade do |t|
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.text "body", null: false
-    t.integer "user_id"
-    t.integer "restaurant_id"
+    t.bigint "user_id"
+    t.bigint "restaurant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["restaurant_id"], name: "index_comments_on_restaurant_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "restaurants", force: :cascade do |t|
+  create_table "restaurants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name"
     t.string "address"
     t.text "business_hours"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2019_04_25_073900) do
     t.decimal "lng", precision: 10, scale: 6
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -67,4 +67,7 @@ ActiveRecord::Schema.define(version: 2019_04_25_073900) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "restaurants"
+  add_foreign_key "comments", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '2'
+services:
+  db:
+    image: mysql:5.7.7
+    environment:
+      MYSQL_DATABASE: kagomeshi_development
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - "3306:3306"
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    volumes:
+      - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    tty: true
+    stdin_open: true
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,15 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+character-set-server = utf8mb4
+skip-character-set-client-handshake
+collation-server = utf8mb4_general_ci
+init-connect = "SET NAMES utf8mb4"
+innodb_file_format = Barracuda
+innodb_file_format_max = Barracuda
+innodb_file_per_table = 1
+innodb_large_prefix = 1


### PR DESCRIPTION
開発環境つくるのが大変なのでDockerで立ち上げられるようにします。
ついでにMySQLの文字コードをutf8mb4にして絵文字が使えるようにします。

立ち上げ方はREADME.mdを参照してください。